### PR TITLE
Binary and project name should be something like driver-kodi

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,8 +2,8 @@
 set -xe
 
 OWNER=ninjasphere
-BIN_NAME=driver-go-chromecast
-PROJECT_NAME=driver-go-chromecast
+BIN_NAME=driver-kodi
+PROJECT_NAME=driver-kodi
 
 
 # Get the parent directory of where this script is.


### PR DESCRIPTION
The name was driver-go-chromecast and my guess is that the script was ported from the chromecast driver project but this bit was not modified accordingly.
